### PR TITLE
Add shell provisioner - fixes apt error

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -60,6 +60,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   ssh_dir = conf['ssh_dir']
   config.vm.synced_folder(ssh_dir, "/home/vagrant/.host-ssh", id: "v-ssh", create: true)
 
+  config.vm.provision "shell",
+    inline: "echo 'APT::Cache-Start 50000000;' > /etc/apt/apt.conf"
+
   cookbooks_dir = conf['devstack_cookbooks_dir']
   config.vm.provision :chef_solo do |chef|
     chef.cookbooks_path = ["cookbooks"]


### PR DESCRIPTION
Fixes this error that sometimes occurs

```
[2013-12-11T15:09:42+00:00] DEBUG: Mixlib::ShellOut::ShellCommandFailed: package[rsync] (vagrant-openstack::devstack-cache line 22) had an error: Mixlib::ShellOut::ShellCommandFailed: Expected process to exit with [0], but received '100'
---- Begin output of apt-cache policy rsync ----
STDOUT:
STDERR: E: Dynamic MMap ran out of room. Please increase the size of APT::Cache-Limit. Current value: 25165824. (man 5 apt.conf)
E: Dynamic MMap ran out of room. Please increase the size of APT::Cache-Limit. Current value: 25165824. (man 5 apt.conf)
E: Error occurred while processing kradioripper (NewVersion2)
E: Problem with MergeList /var/lib/apt/lists/us.archive.ubuntu.com_ubuntu_dists_precise_universe_binary-i386_Packages
E: The package lists or status file could not be parsed or opened.
---- End output of apt-cache policy rsync ----
Ran apt-cache policy rsync returned 100
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/mixlib-shellout-1.1.0/lib/mixlib/shellout.rb:248:in `invalid!'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/mixlib-shellout-1.1.0/lib/mixlib/shellout.rb:234:in `error!'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/mixin/shell_out.rb:36:in `shell_out!'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/provider/package/apt.rb:49:in `check_package_state'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/provider/package/apt.rb:36:in `load_current_resource'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/provider.rb:102:in `run_action'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/resource.rb:593:in `run_action'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/runner.rb:49:in `run_action'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/runner.rb:81:in `converge'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/runner.rb:81:in `each'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/runner.rb:81:in `converge'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/resource_collection.rb:94:in `execute_each_resource'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/resource_collection/stepable_iterator.rb:116:in `call'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/resource_collection/stepable_iterator.rb:116:in `call_iterator_block'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/resource_collection/stepable_iterator.rb:85:in `step'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/resource_collection/stepable_iterator.rb:104:in `iterate'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/resource_collection/stepable_iterator.rb:55:in `each_with_index'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/resource_collection.rb:92:in `execute_each_resource'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/runner.rb:80:in `converge'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/client.rb:378:in `converge'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/client.rb:420:in `do_run'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/client.rb:176:in `run'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/application/solo.rb:230:in `run_application'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/application/solo.rb:218:in `loop'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/application/solo.rb:218:in `run_application'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/application.rb:70:in `run'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/chef-solo:25
/opt/vagrant_ruby/bin/chef-solo:19:in `load'
/opt/vagrant_ruby/bin/chef-solo:19
[2013-12-11T15:09:42+00:00] FATAL: Mixlib::ShellOut::ShellCommandFailed: package[rsync] (vagrant-openstack::devstack-cache line 22) had an error: Mixlib::ShellOut::ShellCommandFailed: Expected process to exit with [0], but received '100'
---- Begin output of apt-cache policy rsync ----
STDOUT:
STDERR: E: Dynamic MMap ran out of room. Please increase the size of APT::Cache-Limit. Current value: 25165824. (man 5 apt.conf)
E: Dynamic MMap ran out of room. Please increase the size of APT::Cache-Limit. Current value: 25165824. (man 5 apt.conf)
E: Error occurred while processing kradioripper (NewVersion2)
E: Problem with MergeList /var/lib/apt/lists/us.archive.ubuntu.com_ubuntu_dists_precise_universe_binary-i386_Packages
E: The package lists or status file could not be parsed or opened.
---- End output of apt-cache policy rsync ----
Ran apt-cache policy rsync returned 100
```
