### PR TITLE
accepts chef license

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -63,6 +63,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   cookbooks_dir = conf['devstack_cookbooks_dir']
   config.vm.provision :chef_solo do |chef|
+    chef.arguments = "--chef-license accept" 
     chef.cookbooks_path = ["cookbooks"]
     chef.log_level = :debug
     chef.run_list = [


### PR DESCRIPTION
This change accepts the Chef product licenses.

Output of a run can be seen below.

fixes #32

```
$ vagrant up
Bringing machine 'default' up with 'virtualbox' provider...
==> default: Importing base box 'trusty'...
==> default: Matching MAC address for NAT networking...
==> default: Setting the name of the VM: trusty
==> default: Clearing any previously set forwarded ports...
==> default: Auto-generating node name for Chef...
==> default: Clearing any previously set network interfaces...
==> default: Preparing network interfaces based on configuration...
    default: Adapter 1: nat
    default: Adapter 2: hostonly
    default: Adapter 3: hostonly
==> default: Forwarding ports...
    default: 22 (guest) => 2222 (host) (adapter 1)
==> default: Running 'pre-boot' VM customizations...
==> default: Booting VM...
==> default: Waiting for machine to boot. This may take a few minutes...
    default: SSH address: 127.0.0.1:2222
    default: SSH username: vagrant
    default: SSH auth method: private key
    default: 
    default: Vagrant insecure key detected. Vagrant will automatically replace
    default: this with a newly generated keypair for better security.
    default: 
    default: Inserting generated public key within guest...
    default: Removing insecure key from the guest if it's present...
    default: Key inserted! Disconnecting and reconnecting using new SSH key...
==> default: Machine booted and ready!
==> default: Checking for guest additions in VM...
    default: The guest additions on this VM do not match the installed version of
    default: VirtualBox! In most cases this is fine, but in rare cases it can
    default: prevent things such as shared folders from working properly. If you see
    default: shared folder errors, please make sure the guest additions within the
    default: virtual machine match the version of VirtualBox you have installed on
    default: your host and reload your VM.
    default: 
    default: Guest Additions Version: 4.3.40
    default: VirtualBox Version: 5.2
==> default: Configuring and enabling network interfaces...
==> default: Mounting shared folders...
    default: /vagrant => /home/jlosito/workspace/vagrant_devstack
    default: /home/vagrant/cache => /home/jlosito/workspace/vagrant_devstack/cache
    default: /home/vagrant/.host-ssh => /home/jlosito/.ssh
    default: /tmp/vagrant-chef/a6d5639fd159f83d4eb4fb9a57cad1c4/cookbooks => /home/jlosito/workspace/vagrant_devstack/cookbooks
==> default: Running provisioner: shell...
    default: Running: inline script
==> default: Running provisioner: chef_solo...
    default: Installing Chef (latest)...
==> default: Generating chef JSON and uploading...
==> default: Running chef-solo...
==> default: [2019-09-30T12:22:26+00:00] DEBUG: Reading products and relationships...
==> default: [2019-09-30T12:22:26+00:00] DEBUG: Successfully read products and relationships
==> default: [2019-09-30T12:22:26+00:00] DEBUG: Searching for the following licenses: ["infra-client", "inspec"]
==> default: [2019-09-30T12:22:26+00:00] DEBUG: Missing licenses remaining: ["infra-client", "inspec"]
==> default: [2019-09-30T12:22:26+00:00] INFO: Persisting a license for Chef Infra Client at path /etc/chef/accepted_licenses/chef_infra_client
==> default: [2019-09-30T12:22:26+00:00] INFO: Persisting a license for Chef InSpec at path /etc/chef/accepted_licenses/inspec
==> default: +---------------------------------------------+
==> default: ✔ 2 product licenses accepted.
==> default: +---------------------------------------------+
==> default: [2019-09-30T12:22:26+00:00] INFO: Started Chef Infra Zero at chefzero://localhost:1 with repository at /tmp/vagrant-chef/a6d5639fd159f83d4eb4fb9a57cad1c4
==> default:   One version per cookbook
==> default: [2019-09-30T12:22:26+00:00] DEBUG: Running Ohai with the following configuration: {:logger=>Chef::Log}
==> default: Starting Chef Infra Client, version 15.1.36
==> default: [2019-09-30T12:22:26+00:00] INFO: *** Chef Infra Client 15.1.36 ***
==> default: [2019-09-30T12:22:26+00:00] INFO: Platform: x86_64-linux
==> default: [2019-09-30T12:22:26+00:00] INFO: Chef-client pid: 3016
==> default: [2019-09-30T12:22:26+00:00] DEBUG: Chef-client request_id: 45600221-9b55-4ad4-88d9-9ea97e903ec4
==> default: [2019-09-30T12:22:26+00:00] DEBUG: Running Ohai with the following configuration: {:logger=>Chef::Log}
==> default: [2019-09-30T12:22:26+00:00] DEBUG: The plugin path /etc/chef/ohai/plugins does not exist. Skipping...
==> default: [2019-09-30T12:22:28+00:00] DEBUG: Plugin Zpools: Could not shell_out "zpool list -H -o name,size,alloc,free,cap,dedup,health,version". Skipping plugin.
==> default: [2019-09-30T12:22:28+00:00] DEBUG: GET /organizations/chef/nodes/vagrant-67b04fb3
==> default: [2019-09-30T12:22:28+00:00] DEBUG: #<ChefZero::RestRequest:0x000000000465d340
```